### PR TITLE
chore: add coverage config to exclude GUI and rename CI workflow

### DIFF
--- a/.github/workflows/ci-test-coverage.yml
+++ b/.github/workflows/ci-test-coverage.yml
@@ -1,4 +1,4 @@
-name: test-cov
+name: CI Test Coverage
 
 on:
   push:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dev = [
     "ruff>=0.12.5",
 ]
 
+[tool.coverage.run]
+omit = ["src/gui/*"]
+
+[tool.coverage.report]
+omit = ["src/gui/*"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Add coverage configuration to `pyproject.toml` to exclude `src/gui/*` from coverage reports
- Rename CI workflow file from `test-cov.yml` to `ci-test-coverage.yml` for better clarity
- Update workflow display name from "test-cov" to "CI Test Coverage"

## Test plan
- [ ] Verify CI workflow runs successfully with the renamed file
- [ ] Confirm coverage reports exclude GUI files

🤖 Generated with [Claude Code](https://claude.com/claude-code)