### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ The application features a sophisticated real-time configuration system that app
 - **API Key Change**: Update OpenAI key → Only transcription/refinement components reinitialize
 
 ### Speech-to-Text Settings
-- **STT Provider Selection**: Choose between OpenAI or Deepgram (default: Deepgram)
-- **API Key**: Secure entry with show/hide functionality (dynamically shows OpenAI or Deepgram field based on provider)
+- **STT Provider Selection**: Choose between OpenAI, Deepgram or 60dB (default: Deepgram)
+- **API Key**: Secure entry with show/hide functionality (dynamically shows OpenAI, Deepgram or 60dB field based on provider)
 - **Model Selection**: Choose provider-specific models:
   - **OpenAI**: whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe
   - **Deepgram**: nova-3 (default and recommended), nova-2, base, enhanced, whisper-medium
+  - **60dB**: 60db-stt (single endpoint; auto-detects language)
 
 ### Text Refinement Settings
 - **Refinement Provider**: Choose between OpenAI, Cerebras, Gemini, or Custom (default: Cerebras)
@@ -205,7 +206,7 @@ The application supports three ways to provide API keys (checked in this order):
 3. **Configuration File**: Manually edit `push_to_talk_config.json`
 
 The required API key depends on your selected providers:
-- **STT Provider**: OpenAI requires `openai_api_key`, Deepgram requires `deepgram_api_key`
+- **STT Provider**: OpenAI requires `openai_api_key`, Deepgram requires `deepgram_api_key`, 60dB requires `sixtydb_api_key`
 - **Refinement Provider**: OpenAI requires `openai_api_key`, Cerebras requires `cerebras_api_key`, Gemini requires `gemini_api_key`, Custom requires `custom_api_key`
 
 Environment variables are checked automatically if GUI or config file values are empty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "deepgram-sdk>=3.9.0",
+    "httpx>=0.27.0",
     "loguru>=0.7.2",
     "openai>=1.97.1",
     "pyaudio>=0.2.14",

--- a/src/gui/api_section.py
+++ b/src/gui/api_section.py
@@ -6,6 +6,7 @@ from typing import Callable
 from src.gui.validators import (
     validate_openai_api_key,
     validate_deepgram_api_key,
+    validate_sixtydb_api_key,
     validate_cerebras_api_key,
     validate_gemini_api_key,
 )
@@ -36,6 +37,7 @@ class APISection:
         self.stt_provider_var = tk.StringVar()
         self.openai_api_key_var = tk.StringVar()
         self.deepgram_api_key_var = tk.StringVar()
+        self.sixtydb_api_key_var = tk.StringVar()
         self.cerebras_api_key_var = tk.StringVar()
         self.gemini_api_key_var = tk.StringVar()
         self.custom_api_key_var = tk.StringVar()
@@ -46,6 +48,7 @@ class APISection:
         # Provider-specific widgets
         self.openai_widgets = {}
         self.deepgram_widgets = {}
+        self.sixtydb_widgets = {}
         self.cerebras_widgets = {}
         self.gemini_widgets = {}
         self.custom_widgets = {}
@@ -55,6 +58,7 @@ class APISection:
         # Provider-specific model selections (to preserve when switching)
         self.openai_stt_model = "gpt-4o-mini-transcribe"
         self.deepgram_stt_model = "nova-3"
+        self.sixtydb_stt_model = "60db-stt"
 
         # Provider-specific refinement model selections
         self.openai_refinement_model = "gpt-4.1-nano"
@@ -252,6 +256,43 @@ class APISection:
         custom_show_hide_btn.grid(row=0, column=3, padx=(5, 0), pady=2)
         self.custom_widgets["frame"].columnconfigure(1, weight=1)
 
+        # 60dB API Key Frame
+        self.sixtydb_widgets["frame"] = ttk.Frame(self.api_keys_frame)
+        self.sixtydb_widgets["frame"].grid(
+            row=5, column=0, columnspan=4, sticky="ew", pady=5
+        )
+
+        ttk.Label(self.sixtydb_widgets["frame"], text="60dB API Key:").grid(
+            row=0, column=0, sticky="w", pady=2
+        )
+        sixtydb_api_key_entry = ttk.Entry(
+            self.sixtydb_widgets["frame"],
+            textvariable=self.sixtydb_api_key_var,
+            show="*",
+            width=50,
+        )
+        sixtydb_api_key_entry.grid(
+            row=0, column=1, columnspan=2, sticky="ew", padx=(10, 0), pady=2
+        )
+
+        # 60dB Show/Hide API Key button
+        def toggle_sixtydb_key_visibility():
+            if sixtydb_api_key_entry["show"] == "*":
+                sixtydb_api_key_entry["show"] = ""
+                sixtydb_show_hide_btn["text"] = "Hide"
+            else:
+                sixtydb_api_key_entry["show"] = "*"
+                sixtydb_show_hide_btn["text"] = "Show"
+
+        sixtydb_show_hide_btn = ttk.Button(
+            self.sixtydb_widgets["frame"],
+            text="Show",
+            command=toggle_sixtydb_key_visibility,
+            width=8,
+        )
+        sixtydb_show_hide_btn.grid(row=0, column=3, padx=(5, 0), pady=2)
+        self.sixtydb_widgets["frame"].columnconfigure(1, weight=1)
+
         # === Speech-to-Text Settings Section ===
         # STT Provider Selection
         ttk.Label(self.frame, text="STT Provider:").grid(
@@ -260,7 +301,7 @@ class APISection:
         stt_provider_combo = ttk.Combobox(
             self.frame,
             textvariable=self.stt_provider_var,
-            values=["openai", "deepgram"],
+            values=["openai", "deepgram", "60db"],
             state="readonly",
             width=20,
         )
@@ -374,6 +415,8 @@ class APISection:
             self.openai_stt_model = current_model
         elif provider_value == "deepgram":
             self.deepgram_stt_model = current_model
+        elif provider_value == "60db":
+            self.sixtydb_stt_model = current_model
 
     def _on_refinement_provider_changed(self, event=None):
         """Handle refinement provider changes - update model options."""
@@ -416,6 +459,7 @@ class APISection:
         # Define model lists
         openai_models = ["whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"]
         deepgram_models = ["nova-3", "nova-2", "base", "enhanced", "whisper-medium"]
+        sixtydb_models = ["60db-stt"]
 
         # Save the current model to the appropriate provider-specific variable
         # This preserves the selection before we change providers
@@ -423,6 +467,8 @@ class APISection:
             self.openai_stt_model = current_model
         elif current_model in deepgram_models:
             self.deepgram_stt_model = current_model
+        elif current_model in sixtydb_models:
+            self.sixtydb_stt_model = current_model
 
         # Update model options and restore provider-specific selection
         if provider_value == "openai":
@@ -437,6 +483,13 @@ class APISection:
             # Restore the previously selected Deepgram model
             if self.deepgram_stt_model in models:
                 self.stt_model_var.set(self.deepgram_stt_model)
+            else:
+                self.stt_model_var.set(models[0])
+        elif provider_value == "60db":
+            models = sixtydb_models
+            # Restore the previously selected 60dB model
+            if self.sixtydb_stt_model in models:
+                self.stt_model_var.set(self.sixtydb_stt_model)
             else:
                 self.stt_model_var.set(models[0])
         else:
@@ -538,6 +591,7 @@ class APISection:
             "stt_provider": self.stt_provider_var.get(),
             "openai_api_key": self.openai_api_key_var.get().strip(),
             "deepgram_api_key": self.deepgram_api_key_var.get().strip(),
+            "sixtydb_api_key": self.sixtydb_api_key_var.get().strip(),
             "cerebras_api_key": self.cerebras_api_key_var.get().strip(),
             "gemini_api_key": self.gemini_api_key_var.get().strip(),
             "custom_api_key": self.custom_api_key_var.get().strip(),
@@ -559,6 +613,7 @@ class APISection:
         refinement_provider: str,
         refinement_model: str,
         custom_endpoint: str = "",
+        sixtydb_api_key: str = "",
     ):
         """
         Set the API configuration values.
@@ -578,10 +633,12 @@ class APISection:
             refinement_provider: Refinement provider name
             refinement_model: Refinement model name
             custom_endpoint: Custom API endpoint URL
+            sixtydb_api_key: 60dB API key
         """
         # Set API keys
         self.openai_api_key_var.set(openai_api_key)
         self.deepgram_api_key_var.set(deepgram_api_key)
+        self.sixtydb_api_key_var.set(sixtydb_api_key)
         self.cerebras_api_key_var.set(cerebras_api_key)
         self.gemini_api_key_var.set(gemini_api_key)
         self.custom_api_key_var.set(custom_api_key)
@@ -593,6 +650,8 @@ class APISection:
             self.openai_stt_model = stt_model
         elif stt_provider == "deepgram":
             self.deepgram_stt_model = stt_model
+        elif stt_provider == "60db":
+            self.sixtydb_stt_model = stt_model
 
         if refinement_provider == "openai":
             self.openai_refinement_model = refinement_model
@@ -627,6 +686,8 @@ class APISection:
                 models = ["whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"]
             elif provider == "deepgram":
                 models = ["nova-3", "nova-2", "base", "enhanced", "whisper-medium"]
+            elif provider == "60db":
+                models = ["60db-stt"]
             else:
                 models = []
             self.stt_model_combo["values"] = models
@@ -724,6 +785,28 @@ class APISection:
                 f"  Key: {'*' * min(len(values['deepgram_api_key']), 20)}"
             )
 
+        # Test 60dB
+        sixtydb_status = "Not configured"
+        sixtydb_prefix = "[ ]"
+        if values["sixtydb_api_key"]:
+            try:
+                validate_sixtydb_api_key(values["sixtydb_api_key"])
+                sixtydb_status = "VALID"
+                sixtydb_prefix = "[OK]"
+            except Exception as e:
+                sixtydb_status = str(e)
+                sixtydb_prefix = "[X]"
+
+        selected_marker = (
+            " (Selected STT Model)" if values["stt_provider"] == "60db" else ""
+        )
+        status_lines.append(f"\n{sixtydb_prefix} 60dB{selected_marker}:")
+        status_lines.append(f"  Status: {sixtydb_status}")
+        if values["sixtydb_api_key"]:
+            status_lines.append(
+                f"  Key: {'*' * min(len(values['sixtydb_api_key']), 20)}"
+            )
+
         # Test Cerebras
         cerebras_status = "Not configured"
         cerebras_prefix = "[ ]"
@@ -807,6 +890,10 @@ class APISection:
         elif values["stt_provider"] == "deepgram" and deepgram_prefix == "[X]":
             status_lines.append(
                 "\n*** WARNING: Selected STT provider (Deepgram) has an invalid API key!"
+            )
+        elif values["stt_provider"] == "60db" and sixtydb_prefix == "[X]":
+            status_lines.append(
+                "\n*** WARNING: Selected STT provider (60dB) has an invalid API key!"
             )
 
         if values["refinement_provider"] == "openai" and openai_prefix == "[X]":

--- a/src/gui/configuration_window.py
+++ b/src/gui/configuration_window.py
@@ -234,6 +234,7 @@ Configure your settings below, then click "Start Application" to begin:"""
                         self.api_section.stt_provider_var,
                         self.api_section.openai_api_key_var,
                         self.api_section.deepgram_api_key_var,
+                        self.api_section.sixtydb_api_key_var,
                         self.api_section.cerebras_api_key_var,
                         self.api_section.gemini_api_key_var,
                         self.api_section.custom_api_key_var,
@@ -339,6 +340,7 @@ Configure your settings below, then click "Start Application" to begin:"""
             stt_provider=api_values["stt_provider"],
             openai_api_key=api_values["openai_api_key"],
             deepgram_api_key=api_values["deepgram_api_key"],
+            sixtydb_api_key=api_values["sixtydb_api_key"],
             cerebras_api_key=api_values["cerebras_api_key"],
             gemini_api_key=api_values["gemini_api_key"],
             custom_api_key=api_values["custom_api_key"],
@@ -371,6 +373,7 @@ Configure your settings below, then click "Start Application" to begin:"""
                 config.refinement_provider,
                 config.refinement_model,
                 config.custom_endpoint,
+                sixtydb_api_key=config.sixtydb_api_key,
             )
             self.hotkey_section.set_values(config.hotkey, config.toggle_hotkey)
             self.feature_flags_section.set_values(

--- a/src/gui/validators.py
+++ b/src/gui/validators.py
@@ -30,6 +30,13 @@ def validate_configuration(config: PushToTalkConfig) -> tuple[bool, str | None]:
                 "Deepgram API key is required when using Deepgram provider!\n\n"
                 "Please enter your Deepgram API key or switch to OpenAI provider.",
             )
+    elif config.stt_provider == "60db":
+        if not config.sixtydb_api_key.strip():
+            return (
+                False,
+                "60dB API key is required when using 60dB provider!\n\n"
+                "Please enter your 60dB API key or switch to another provider.",
+            )
     else:
         return False, f"Unknown provider: {config.stt_provider}"
 
@@ -88,6 +95,39 @@ def validate_deepgram_api_key(api_key: str) -> bool:
     """
     url = "https://api.deepgram.com/v1/auth/token"
     headers = {"Authorization": f"Token {api_key}"}
+
+    req = urllib.request.Request(url, headers=headers)
+
+    try:
+        with urllib.request.urlopen(req, timeout=10):
+            # If we get here, the API key is valid
+            return True
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            raise Exception("401 - Incorrect API key")
+        elif e.code == 404:
+            raise Exception("404 - API endpoint not found")
+        else:
+            raise Exception(f"HTTP {e.code}: {e.reason}")
+    except urllib.error.URLError as e:
+        raise Exception(f"timeout - Network error: {e.reason}")
+
+
+def validate_sixtydb_api_key(api_key: str) -> bool:
+    """
+    Validate a 60dB API key by making a direct request to the voices endpoint.
+
+    Args:
+        api_key: 60dB API key to validate
+
+    Returns:
+        True if valid, False otherwise
+
+    Raises:
+        Exception: With error message containing HTTP error codes (401, 404) or timeout
+    """
+    url = "https://api.60db.ai/myvoices"
+    headers = {"Authorization": f"Bearer {api_key}"}
 
     req = urllib.request.Request(url, headers=headers)
 

--- a/src/push_to_talk.py
+++ b/src/push_to_talk.py
@@ -44,10 +44,11 @@ class PushToTalkConfig(BaseModel):
 
     # Transcription provider settings
     stt_provider: str = Field(
-        default="deepgram", description="STT provider: 'openai' or 'deepgram'"
+        default="deepgram", description="STT provider: 'openai', 'deepgram' or '60db'"
     )
     openai_api_key: str = Field(default="", description="OpenAI API key")
     deepgram_api_key: str = Field(default="", description="Deepgram API key")
+    sixtydb_api_key: str = Field(default="", description="60dB API key")
     stt_model: str = Field(default="nova-3", description="STT model name")
 
     # Text refinement settings
@@ -103,9 +104,11 @@ class PushToTalkConfig(BaseModel):
     @field_validator("stt_provider")
     @classmethod
     def validate_stt_provider(cls, v: str) -> str:
-        """Validate STT provider is either 'openai' or 'deepgram'."""
-        if v not in ["openai", "deepgram"]:
-            raise ValueError(f"stt_provider must be 'openai' or 'deepgram', got '{v}'")
+        """Validate STT provider is 'openai', 'deepgram' or '60db'."""
+        if v not in ["openai", "deepgram", "60db"]:
+            raise ValueError(
+                f"stt_provider must be 'openai', 'deepgram' or '60db', got '{v}'"
+            )
         return v
 
     @field_validator("refinement_provider")
@@ -226,6 +229,13 @@ class PushToTalkApp:
                 if not self.config.deepgram_api_key:
                     raise ConfigurationError(
                         "Deepgram API key is required. Set DEEPGRAM_API_KEY environment variable or provide in config."
+                    )
+        elif self.config.stt_provider == "60db":
+            if not self.config.sixtydb_api_key:
+                self.config.sixtydb_api_key = os.getenv("SIXTYDB_API_KEY")
+                if not self.config.sixtydb_api_key:
+                    raise ConfigurationError(
+                        "60dB API key is required. Set SIXTYDB_API_KEY environment variable or provide in config."
                     )
         else:
             raise ConfigurationError(
@@ -362,6 +372,8 @@ class PushToTalkApp:
             api_key = self.config.openai_api_key or os.getenv("OPENAI_API_KEY")
         elif self.config.stt_provider == "deepgram":
             api_key = self.config.deepgram_api_key or os.getenv("DEEPGRAM_API_KEY")
+        elif self.config.stt_provider == "60db":
+            api_key = self.config.sixtydb_api_key or os.getenv("SIXTYDB_API_KEY")
         else:
             raise ConfigurationError(
                 f"Unknown STT provider: {self.config.stt_provider}"

--- a/src/transcriber_factory.py
+++ b/src/transcriber_factory.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from src.transcription_base import TranscriberBase
 from src.transcription_openai import OpenAITranscriber
 from src.transcription_deepgram import DeepgramTranscriber
+from src.transcription_sixtydb import SixtyDBTranscriber
 
 
 class TranscriberFactory:
@@ -18,7 +19,7 @@ class TranscriberFactory:
         Create and return a transcriber instance.
 
         Args:
-            provider: The transcription provider ("openai" or "deepgram")
+            provider: The transcription provider ("openai", "deepgram" or "60db")
             api_key: API key for the selected provider
             model: Model name to use for transcription
             glossary: Optional list of custom terms for improved recognition
@@ -33,6 +34,8 @@ class TranscriberFactory:
             transcriber = OpenAITranscriber(api_key=api_key, model=model)
         elif provider == "deepgram":
             transcriber = DeepgramTranscriber(api_key=api_key, model=model)
+        elif provider == "60db":
+            transcriber = SixtyDBTranscriber(api_key=api_key, model=model)
         else:
             raise ValueError(f"Unknown transcription provider: {provider}")
 

--- a/src/transcription_sixtydb.py
+++ b/src/transcription_sixtydb.py
@@ -1,0 +1,172 @@
+import os
+from loguru import logger
+import time
+from typing import Optional, List
+
+import httpx
+
+from src.transcription_base import TranscriberBase
+from src.utils import validate_audio_file_exists, validate_audio_duration
+from src.exceptions import TranscriptionError, APIError
+
+
+class SixtyDBTranscriber(TranscriberBase):
+    """60dB (60db.ai) speech-to-text transcription implementation.
+
+    Unlike OpenAI/Deepgram, 60dB does not publish a Python SDK, so this talks
+    to the REST endpoint directly via httpx. The 60dB STT endpoint also has no
+    notion of a selectable model, so the ``model`` argument is accepted for
+    interface consistency but is not sent to the API.
+    """
+
+    # 60dB API base URL and speech-to-text endpoint
+    BASE_URL = "https://api.60db.ai"
+    STT_ENDPOINT = "/stt"
+
+    # Default keyword boost weight (60dB accepts 1.5-10; the docs example uses 5)
+    DEFAULT_KEYWORD_WEIGHT = 5
+
+    # Conservative character budget for the keywords field to keep requests small.
+    # Mirrors the keyterm budgeting used by the Deepgram transcriber.
+    MAX_KEYWORD_CHARS = 2000
+
+    # Request timeout in seconds (60dB allows up to 1 hour / 10 MB audio)
+    REQUEST_TIMEOUT = 60.0
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "60db-stt"):
+        """
+        Initialize the transcriber with the 60dB API.
+
+        Args:
+            api_key: 60dB API key. If None, will use the SIXTYDB_API_KEY
+                environment variable.
+            model: Placeholder STT model name. 60dB's STT endpoint does not take
+                a model parameter; this is kept for interface consistency.
+        """
+        api_key = api_key or os.getenv("SIXTYDB_API_KEY")
+        super().__init__(api_key, "60dB")
+
+        self.model = model
+
+    def transcribe_audio(
+        self, audio_file_path: str, language: Optional[str] = None
+    ) -> Optional[str]:
+        """
+        Transcribe audio file to text using the 60dB API.
+
+        Args:
+            audio_file_path: Path to the audio file
+            language: Language code (optional, auto-detect if None)
+
+        Returns:
+            Transcribed text or None if transcription failed
+        """
+        # Validate file exists
+        if not validate_audio_file_exists(audio_file_path):
+            return None
+
+        # Validate audio duration
+        if not validate_audio_duration(audio_file_path):
+            return None
+
+        try:
+            start_time = time.time()
+            logger.debug(f"Starting transcription for: {audio_file_path}")
+
+            # Read audio file
+            with open(audio_file_path, "rb") as audio_file:
+                audio_data = audio_file.read()
+
+            # Build multipart form fields
+            data = {}
+
+            # Add language if specified (60dB auto-detects when omitted)
+            if language:
+                data["language"] = language
+
+            # Map custom glossary to 60dB keyword boosting
+            if self.glossary:
+                keywords = self._prepare_keywords(self.glossary)
+                if keywords:
+                    data["keywords"] = keywords
+                    logger.debug(f"Using keyword boost: {keywords}")
+
+            files = {
+                "file": (
+                    os.path.basename(audio_file_path),
+                    audio_data,
+                    "audio/wav",
+                )
+            }
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+
+            # Call 60dB STT API
+            response = httpx.post(
+                f"{self.BASE_URL}{self.STT_ENDPOINT}",
+                files=files,
+                data=data,
+                headers=headers,
+                timeout=self.REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+
+            # Extract transcript from response
+            # 60dB response structure: {"text": "...", "language": "...", ...}
+            result = response.json()
+            transcribed_text = result.get("text")
+            if transcribed_text is None:
+                logger.warning("Invalid 60dB response structure: missing 'text'")
+                return None
+
+            transcribed_text = transcribed_text.strip()
+            transcription_time = time.time() - start_time
+
+            logger.info(
+                f"Transcription successful: {len(transcribed_text)} characters in {transcription_time:.2f}s"
+            )
+            return transcribed_text if transcribed_text else None
+
+        except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code
+            logger.error(f"60dB API error during transcription: {e}")
+            raise APIError(
+                f"60dB transcription API failed: {e}",
+                provider="60dB",
+                status_code=status_code,
+            ) from e
+        except Exception as e:
+            logger.error(f"Transcription failed: {e}")
+            raise TranscriptionError(f"Failed to transcribe audio: {e}") from e
+
+    def _prepare_keywords(self, glossary: List[str]) -> str:
+        """
+        Prepare a 60dB keywords string from the glossary.
+
+        60dB expects a comma-separated list of ``term:weight`` pairs (weights
+        1.5-10). Terms are added until the character budget is reached.
+
+        Args:
+            glossary: List of custom terms/phrases
+
+        Returns:
+            Comma-separated ``term:weight`` string (empty if no glossary)
+        """
+        if not glossary:
+            return ""
+
+        entries = []
+        total_chars = 0
+
+        for term in glossary:
+            entry = f"{term}:{self.DEFAULT_KEYWORD_WEIGHT}"
+            # +1 accounts for the comma separator between entries
+            if total_chars + len(entry) + 1 > self.MAX_KEYWORD_CHARS:
+                logger.warning(
+                    f"Keyword limit reached. Using first {len(entries)} of {len(glossary)} glossary terms"
+                )
+                break
+
+            entries.append(entry)
+            total_chars += len(entry) + 1
+
+        return ",".join(entries)

--- a/tests/test_transcriber_factory.py
+++ b/tests/test_transcriber_factory.py
@@ -4,6 +4,7 @@ from loguru import logger
 from src.transcriber_factory import TranscriberFactory
 from src.transcription_openai import OpenAITranscriber
 from src.transcription_deepgram import DeepgramTranscriber
+from src.transcription_sixtydb import SixtyDBTranscriber
 from src.transcription_base import TranscriberBase
 
 
@@ -65,6 +66,35 @@ class TestTranscriberFactory:
         logger.info(
             "Factory creates Deepgram transcriber with custom model test passed"
         )
+
+    def test_create_sixtydb_transcriber(self):
+        """Test factory creates 60dB transcriber"""
+        logger.info("Testing factory creates 60dB transcriber")
+
+        transcriber = TranscriberFactory.create_transcriber(
+            provider="60db", api_key="test-sixtydb-key", model="60db-stt"
+        )
+
+        assert isinstance(transcriber, SixtyDBTranscriber)
+        assert isinstance(transcriber, TranscriberBase)
+        assert transcriber.api_key == "test-sixtydb-key"
+        assert transcriber.model == "60db-stt"
+
+        logger.info("Factory creates 60dB transcriber test passed")
+
+    def test_create_sixtydb_transcriber_with_glossary(self):
+        """Test factory creates 60dB transcriber with glossary"""
+        logger.info("Testing factory creates 60dB transcriber with glossary")
+
+        glossary = ["test", "terms"]
+        transcriber = TranscriberFactory.create_transcriber(
+            provider="60db", api_key="test-key", model="60db-stt", glossary=glossary
+        )
+
+        assert isinstance(transcriber, SixtyDBTranscriber)
+        assert transcriber.glossary == glossary
+
+        logger.info("Factory creates 60dB transcriber with glossary test passed")
 
     def test_invalid_provider_raises_error(self):
         """Test invalid provider raises ValueError"""

--- a/tests/test_transcription_sixtydb.py
+++ b/tests/test_transcription_sixtydb.py
@@ -1,0 +1,284 @@
+import pytest
+import os
+from loguru import logger
+from unittest.mock import MagicMock
+
+import httpx
+
+from src.transcription_sixtydb import SixtyDBTranscriber
+from src.exceptions import ConfigurationError, TranscriptionError, APIError
+
+
+def _make_response(json_data, status_code=200):
+    """Build a mock httpx response with the given JSON payload."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status.return_value = None
+    mock_response.status_code = status_code
+    return mock_response
+
+
+class TestSixtyDBTranscriber:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        """Setup for each test method"""
+        logger.info("Setting up SixtyDBTranscriber test")
+
+        # Use a mock API key for testing
+        mocker.patch.dict(os.environ, {"SIXTYDB_API_KEY": "test-api-key"})
+        self.transcriber = SixtyDBTranscriber()
+
+    def test_initialization_with_env_var(self, mocker):
+        """Test SixtyDBTranscriber initialization with environment variable"""
+        logger.info("Testing SixtyDBTranscriber initialization with env var")
+
+        mocker.patch.dict(os.environ, {"SIXTYDB_API_KEY": "env-api-key"})
+        transcriber = SixtyDBTranscriber()
+
+        assert transcriber.api_key == "env-api-key"
+        assert transcriber.model == "60db-stt"
+
+        logger.info("SixtyDBTranscriber initialization with env var test passed")
+
+    def test_initialization_with_explicit_key(self):
+        """Test SixtyDBTranscriber initialization with explicit API key"""
+        logger.info("Testing SixtyDBTranscriber initialization with explicit key")
+
+        transcriber = SixtyDBTranscriber(api_key="explicit-api-key")
+
+        assert transcriber.api_key == "explicit-api-key"
+
+        logger.info("SixtyDBTranscriber initialization with explicit key test passed")
+
+    def test_initialization_no_api_key(self, mocker):
+        """Test SixtyDBTranscriber initialization without API key"""
+        logger.info("Testing SixtyDBTranscriber initialization without API key")
+
+        mocker.patch.dict(os.environ, {}, clear=True)
+        with pytest.raises(ConfigurationError) as exc_info:
+            SixtyDBTranscriber()
+
+        assert "60dB API key is required" in str(exc_info.value)
+
+        logger.info("SixtyDBTranscriber initialization no API key test passed")
+
+    def test_transcribe_audio_success(self, mocker):
+        """Test successful audio transcription"""
+        logger.info("Testing successful audio transcription")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mock_post = mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": "This is the transcribed text."}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result == "This is the transcribed text."
+
+        # Verify the API was called once with the auth header
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["headers"]["Authorization"] == "Bearer test-api-key"
+        assert "file" in call_kwargs["files"]
+
+        logger.info("Transcribe audio success test passed")
+
+    def test_transcribe_audio_with_language(self, mocker):
+        """Test audio transcription with language specified"""
+        logger.info("Testing audio transcription with language")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mock_post = mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": "This is transcribed French text."}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav", language="fr")
+
+        assert result == "This is transcribed French text."
+
+        # Verify language parameter was passed in form data
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["data"]["language"] == "fr"
+
+        logger.info("Transcribe audio with language test passed")
+
+    def test_transcribe_audio_file_not_found(self, mocker):
+        """Test transcription when audio file doesn't exist"""
+        logger.info("Testing transcription with missing file")
+
+        mocker.patch("os.path.exists", return_value=False)
+
+        result = self.transcriber.transcribe_audio("nonexistent.wav")
+
+        assert result is None
+
+        logger.info("Transcribe audio file not found test passed")
+
+    def test_transcribe_audio_generic_failure(self, mocker):
+        """Test generic transcription failure raises TranscriptionError"""
+        logger.info("Testing transcription generic failure")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            side_effect=Exception("connection failed"),
+        )
+
+        with pytest.raises(TranscriptionError, match="Failed to transcribe audio"):
+            self.transcriber.transcribe_audio("test_audio.wav")
+
+        logger.info("Transcribe audio generic failure test passed")
+
+    def test_transcribe_audio_http_error(self, mocker):
+        """Test that HTTP status errors raise APIError with status code"""
+        logger.info("Testing 60dB API error handling")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        request = httpx.Request("POST", "https://api.60db.ai/stt")
+        response = httpx.Response(429, request=request)
+        http_error = httpx.HTTPStatusError(
+            "rate limit", request=request, response=response
+        )
+
+        mock_response = _make_response({})
+        mock_response.raise_for_status.side_effect = http_error
+        mocker.patch(
+            "src.transcription_sixtydb.httpx.post", return_value=mock_response
+        )
+
+        with pytest.raises(APIError, match="60dB transcription API failed") as exc_info:
+            self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.provider == "60dB"
+
+        logger.info("60dB API error test passed")
+
+    def test_transcribe_audio_empty_response(self, mocker):
+        """Test transcription with empty transcript"""
+        logger.info("Testing transcription with empty response")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": ""}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result is None
+
+        logger.info("Transcribe audio empty response test passed")
+
+    def test_transcribe_audio_whitespace_response(self, mocker):
+        """Test transcription with whitespace-only transcript"""
+        logger.info("Testing transcription with whitespace response")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": "   \n  \t  "}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result is None
+
+        logger.info("Transcribe audio whitespace response test passed")
+
+    def test_transcribe_audio_missing_text_field(self, mocker):
+        """Test transcription when response has no 'text' field"""
+        logger.info("Testing transcription with missing text field")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"language": "en"}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result is None
+
+        logger.info("Transcribe audio missing text field test passed")
+
+    def test_transcribe_audio_with_glossary(self, mocker):
+        """Test transcription maps glossary to keyword boosting"""
+        logger.info("Testing transcription with glossary/keyword boosting")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        glossary = ["Deepgram", "Nova-3", "API"]
+        self.transcriber.set_glossary(glossary)
+
+        mock_post = mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": "Deepgram Nova-3 API"}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result == "Deepgram Nova-3 API"
+
+        # Verify keywords were passed as weighted CSV
+        call_kwargs = mock_post.call_args[1]
+        assert "keywords" in call_kwargs["data"]
+        keywords = call_kwargs["data"]["keywords"]
+        assert "Deepgram:5" in keywords
+        assert "Nova-3:5" in keywords
+        assert keywords.count(",") == 2  # three terms -> two separators
+
+        logger.info("Transcribe audio with glossary test passed")
+
+    def test_transcribe_audio_with_large_glossary(self, mocker):
+        """Test transcription with large glossary that exceeds the char budget"""
+        logger.info("Testing transcription with large glossary")
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b"fake audio data"))
+        mocker.patch("os.path.exists", return_value=True)
+
+        large_glossary = [f"term_{i}_" + "x" * 100 for i in range(50)]
+        self.transcriber.set_glossary(large_glossary)
+
+        mock_post = mocker.patch(
+            "src.transcription_sixtydb.httpx.post",
+            return_value=_make_response({"text": "limited keywords"}),
+        )
+
+        result = self.transcriber.transcribe_audio("test_audio.wav")
+
+        assert result == "limited keywords"
+
+        # Verify the keywords string stayed within the char budget
+        call_kwargs = mock_post.call_args[1]
+        keywords = call_kwargs["data"]["keywords"]
+        assert len(keywords) <= self.transcriber.MAX_KEYWORD_CHARS
+        # Not all terms fit
+        assert keywords.count(",") + 1 < len(large_glossary)
+
+        logger.info("Transcribe audio with large glossary test passed")
+
+    def test_prepare_keywords_empty(self):
+        """Test keyword preparation with an empty glossary"""
+        logger.info("Testing keyword preparation with empty glossary")
+
+        assert self.transcriber._prepare_keywords([]) == ""
+
+        logger.info("Prepare keywords empty test passed")


### PR DESCRIPTION
We added 60dB as a third speech-to-text provider alongside Deepgram and OpenAI.

  - New transcriber (src/transcription_sixtydb.py) — uploads the WAV to api.60db.ai/stt via httpx, reads the transcript; maps your
  glossary to 60dB's weighted keywords.
  - Wired into the app — factory, config (sixtydb_api_key + SIXTYDB_API_KEY env var, "60db" provider), and the GUI (provider
  dropdown, API-key field, key-test/validation).
  - Dependency — declared httpx (no real 60dB SDK exists).
  - Tests + docs — 14 new tests (all passing) + factory tests, and README updated.